### PR TITLE
Use Python Debian images instead of vanilla Debian images

### DIFF
--- a/postgres-debezium-cdc-example/database-setup/Dockerfile
+++ b/postgres-debezium-cdc-example/database-setup/Dockerfile
@@ -1,6 +1,4 @@
-FROM debian:bullseye-slim
-
-RUN apt update && apt upgrade -y && apt install -y python3 python3-pip && rm -rf /var/cache/apt/*
+FROM python:3-slim
 
 WORKDIR /app
 COPY setup_database.py /app/

--- a/postgres-debezium-cdc-example/printing-consumer/Dockerfile
+++ b/postgres-debezium-cdc-example/printing-consumer/Dockerfile
@@ -1,6 +1,4 @@
-FROM debian:bullseye-slim
-
-RUN apt update && apt upgrade -y && apt install -y python3 python3-pip curl && rm -rf /var/cache/apt/*
+FROM python:3-slim
 
 WORKDIR /app
 COPY test_consumer.py /app/

--- a/postgres-debezium-cdc-example/todo-generator/Dockerfile
+++ b/postgres-debezium-cdc-example/todo-generator/Dockerfile
@@ -1,6 +1,4 @@
-FROM debian:bullseye-slim
-
-RUN apt update && apt upgrade -y && apt install -y python3 python3-pip && rm -rf /var/cache/apt/*
+FROM python:3-slim
 
 WORKDIR /app
 COPY todo_generator.py /app/


### PR DESCRIPTION
By using the images with Python already installed, we speed up the image build time by quite a bit.