### PR TITLE
Install build essentials to printing-consumer Dockerfile to ensure gcc dependency is met in Postgres example

### DIFF
--- a/postgres-debezium-cdc-example/printing-consumer/Dockerfile
+++ b/postgres-debezium-cdc-example/printing-consumer/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3-slim
 WORKDIR /app
 COPY test_consumer.py /app/
 
+RUN apt-get update && \
+  apt-get install -y build-essential
+
 RUN pip3 install -U pip wheel
 RUN pip3 install memphis-py
 


### PR DESCRIPTION
Fixes the following error when building images via `docker compose build --pull --no-cache` ...

```
19.77 Building wheels for collected packages: memphis-py, mmh3, nats-py
19.77   Building wheel for memphis-py (pyproject.toml): started
20.69   Building wheel for memphis-py (pyproject.toml): finished with status 'done'
20.69   Created wheel for memphis-py: filename=memphis_py-1.1.4-py3-none-any.whl size=38632 sha256=2696484fa77c7a63780cd009770c020659f54426a3ab1dc81af604c5eed43a8e
20.69   Stored in directory: /root/.cache/pip/wheels/5e/9a/f2/93eefd808d2128f5cc8ac8576d290a270030dddad03b2474b8
20.71   Building wheel for mmh3 (pyproject.toml): started
21.67   Building wheel for mmh3 (pyproject.toml): finished with status 'error'
21.69   error: subprocess-exited-with-error
21.69
21.69   × Building wheel for mmh3 (pyproject.toml) did not run successfully.
21.69   │ exit code: 1
21.69   ╰─> [33 lines of output]
21.69       running bdist_wheel
21.69       running build
21.69       running build_py
21.69       creating build
21.69       creating build/lib.linux-x86_64-cpython-312
21.69       creating build/lib.linux-x86_64-cpython-312/mmh3
21.69       creating build/lib.linux-x86_64-cpython-312/mmh3/_mmh3
21.69       copying src/mmh3/_mmh3/refresh.py -> build/lib.linux-x86_64-cpython-312/mmh3/_mmh3
21.69       running egg_info
21.69       writing src/mmh3.egg-info/PKG-INFO
21.69       writing dependency_links to src/mmh3.egg-info/dependency_links.txt
21.69       writing requirements to src/mmh3.egg-info/requires.txt
21.69       writing top-level names to src/mmh3.egg-info/top_level.txt
21.69       reading manifest file 'src/mmh3.egg-info/SOURCES.txt'
21.69       reading manifest template 'MANIFEST.in'
21.69       adding license file 'LICENSE'
21.69       writing manifest file 'src/mmh3.egg-info/SOURCES.txt'
21.69       copying src/mmh3/__init__.pyi -> build/lib.linux-x86_64-cpython-312/mmh3
21.69       copying src/mmh3/hashlib.h -> build/lib.linux-x86_64-cpython-312/mmh3
21.69       copying src/mmh3/mmh3module.c -> build/lib.linux-x86_64-cpython-312/mmh3
21.69       copying src/mmh3/py.typed -> build/lib.linux-x86_64-cpython-312/mmh3
21.69       copying src/mmh3/_mmh3/FILE_HEADER -> build/lib.linux-x86_64-cpython-312/mmh3/_mmh3
21.69       copying src/mmh3/_mmh3/README.md -> build/lib.linux-x86_64-cpython-312/mmh3/_mmh3
21.69       copying src/mmh3/_mmh3/murmurhash3.c -> build/lib.linux-x86_64-cpython-312/mmh3/_mmh3
21.69       copying src/mmh3/_mmh3/murmurhash3.h -> build/lib.linux-x86_64-cpython-312/mmh3/_mmh3
21.69       running build_ext
21.69       building 'mmh3' extension
21.69       creating build/temp.linux-x86_64-cpython-312
21.69       creating build/temp.linux-x86_64-cpython-312/src
21.69       creating build/temp.linux-x86_64-cpython-312/src/mmh3
21.69       creating build/temp.linux-x86_64-cpython-312/src/mmh3/_mmh3
21.69       gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/usr/local/include/python3.12 -c ./src/mmh3/_mmh3/murmurhash3.c -o build/temp.linux-x86_64-cpython-312/./src/mmh3/_mmh3/murmurhash3.o
21.69       error: command 'gcc' failed: No such file or directory
21.69       [end of output]
21.69
21.69   note: This error originates from a subprocess, and is likely not a problem with pip.
21.69   ERROR: Failed building wheel for mmh3
21.69   Building wheel for nats-py (pyproject.toml): started
22.38   Building wheel for nats-py (pyproject.toml): finished with status 'done'
22.38   Created wheel for nats-py: filename=nats_py-2.6.0-py3-none-any.whl size=73015 sha256=148fa7d5de9f8ce683748b8bfc8eb7350245e15480807e8c12e660d3a0db10bb
22.38   Stored in directory: /root/.cache/pip/wheels/9d/e6/8d/59fc4776ddb688783bf259bb298d0a0d9bef8b4772fc870b49
22.39 Successfully built memphis-py nats-py
22.39 Failed to build mmh3
22.39 ERROR: Could not build wheels for mmh3, which is required to install pyproject.toml-based projects
```